### PR TITLE
Fix typo error in the ReadME file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import os
 from autogen.agentchat import ConversableAgent
 
 from fastagency import UI
-from fastagency.runtimes.autogen.base import AutoGenWorkflows
+from fastagency.runtime.autogen.base import AutoGenWorkflows
 from fastagency.ui.console import ConsoleUI
 
 from fastagency import FastAgency


### PR DESCRIPTION
Fix a typo in the `from fastagency.runtimes.autogen.base import AutoGenWorkflows` import which is causing an unnecessary import error.

# Description

<!-- Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context. -->

<!-- Fixes # (issue number) -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] I have included code examples to illustrate the modifications
